### PR TITLE
Allow admin to upload client documents

### DIFF
--- a/src/app/quotes/tabs/PieceJointeTab.tsx
+++ b/src/app/quotes/tabs/PieceJointeTab.tsx
@@ -301,7 +301,7 @@ export default function PieceJointeTab({ quote }: PieceJointeTabProps) {
         <h2 className="text-xl font-semibold mb-4">Gestion des documents</h2>
 
         {/* Interface Courtier - Upload de documents */}
-        {isBroker && (
+        {(isBroker || isAdmin) && (
           <div className="mb-6 p-4 border border-blue-200 rounded-lg bg-blue-50">
             <h3 className="font-medium mb-3">Ajouter un document</h3>
             <div className="space-y-3">


### PR DESCRIPTION
Allow admins to upload client documents in the PieceJointe tab to resolve issue LES-100.

---
Linear Issue: [LES-100](https://linear.app/les-bavarois/issue/LES-100/ladmin-doit-aussi-pouvoir-upload-les-documents-du-clients-dans-longlet)

<a href="https://cursor.com/background-agent?bcId=bc-55382a03-9ce7-47ea-a19b-85502ea729b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-55382a03-9ce7-47ea-a19b-85502ea729b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

